### PR TITLE
fix(ci): use detect-secrets CLI instead of nonexistent v2 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Check for known vulnerabilities
         run: pnpm audit --prod || true
       - name: Detect secrets
-        uses: Yelp/detect-secrets-action@v2
-        with:
-          baseline_file: .secrets.baseline
+        run: |
+          pip install detect-secrets
+          detect-secrets scan --baseline .secrets.baseline
+          detect-secrets audit --report .secrets.baseline
 
   gate:
     name: "All Checks"


### PR DESCRIPTION
The Yelp/detect-secrets-action@v2 doesn't exist, causing Security Scan to fail at setup. Replaced with direct CLI install + run. Verified green on PR #18.